### PR TITLE
Ac 321

### DIFF
--- a/db/migrations/000001_init.down.sql
+++ b/db/migrations/000001_init.down.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-DROP TABLE project_users;
-DROP TABLE roles;
+-- DROP TABLE project_users;
+-- DROP TABLE roles;
 DROP TABLE todos;
 DROP TABLE projects;
 DROP TABLE priorities;

--- a/db/migrations/000001_init.up.sql
+++ b/db/migrations/000001_init.up.sql
@@ -16,7 +16,7 @@ CREATE TABLE "todos" (
                          "description" varchar,
                          "done" bool NOT NULL DEFAULT false,
                          "priority" varchar(20) NOT NULL DEFAULT 'mid',
-                         "due_date" date,
+--                          "due_date" date,
                          "project_id" uuid NOT NULL,
                          "user_id" uuid NOT NULL,
                          "created_at" timestamptz NOT NULL DEFAULT 'now()',
@@ -34,31 +34,25 @@ CREATE TABLE "projects" (
                             "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
                             "owner_id" uuid NOT NULL,
                             "name" varchar(40) UNIQUE NOT NULL,
-                            "invitation_token" varchar(40) UNIQUE NOT NULL,
+--                             "invitation_token" varchar(40) UNIQUE NOT NULL,
                             "created_at" timestamptz NOT NULL DEFAULT 'now()',
                             "updated_at" timestamptz NOT NULL DEFAULT 'now()'
 );
 
-CREATE TABLE "project_users" (
-                                 "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-                                 "project_id" uuid NOT NULL,
-                                 "user_id" uuid NOT NULL,
-                                 "role" varchar(20) NOT NULL DEFAULT 'editor',
-                                 "created_at" timestamptz NOT NULL DEFAULT 'now()',
-                                 "updated_at" timestamptz NOT NULL DEFAULT 'now()'
-);
-
-CREATE TABLE "roles" (
-                         "role" varchar(20) PRIMARY KEY,
-                         "created_at" timestamptz NOT NULL DEFAULT 'now()',
-                         "updated_at" timestamptz NOT NULL DEFAULT 'now()'
-);
-
-CREATE UNIQUE INDEX ON "project_users" ("project_id", "user_id");
-
-ALTER TABLE "project_users" ADD FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
-ALTER TABLE "project_users" ADD FOREIGN KEY ("user_id") REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
+-- CREATE TABLE "project_users" (
+--                                  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+--                                  "project_id" uuid NOT NULL,
+--                                  "user_id" uuid NOT NULL,
+--                                  "role" varchar(20) NOT NULL DEFAULT 'editor',
+--                                  "created_at" timestamptz NOT NULL DEFAULT 'now()',
+--                                  "updated_at" timestamptz NOT NULL DEFAULT 'now()'
+-- );
+--
+-- CREATE TABLE "roles" (
+--                          "role" varchar(20) PRIMARY KEY,
+--                          "created_at" timestamptz NOT NULL DEFAULT 'now()',
+--                          "updated_at" timestamptz NOT NULL DEFAULT 'now()'
+-- );
 
 ALTER TABLE "todos" ADD FOREIGN KEY ("user_id") REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
@@ -66,8 +60,16 @@ ALTER TABLE "todos" ADD FOREIGN KEY ("project_id") REFERENCES "projects" ("id") 
 
 ALTER TABLE "projects" ADD FOREIGN KEY ("owner_id") REFERENCES "users" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
-ALTER TABLE "project_users" ADD FOREIGN KEY ("role") REFERENCES "roles" ("role") ON DELETE SET NULL ON UPDATE CASCADE;
-
 ALTER TABLE "todos" ADD FOREIGN KEY ("priority") REFERENCES "priorities" ("name") ON DELETE SET NULL ON UPDATE CASCADE;
+
+
+-- CREATE UNIQUE INDEX ON "project_users" ("project_id", "user_id");
+
+-- ALTER TABLE "project_users" ADD FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
+--
+-- ALTER TABLE "project_users" ADD FOREIGN KEY ("user_id") REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+
+-- ALTER TABLE "project_users" ADD FOREIGN KEY ("role") REFERENCES "roles" ("role") ON DELETE SET NULL ON UPDATE CASCADE;
 
 COMMIT;

--- a/db/migrations/000002_add_update_trigger.down.sql
+++ b/db/migrations/000002_add_update_trigger.down.sql
@@ -1,11 +1,11 @@
 BEGIN;
 
 drop trigger update_trigger on todos;
+drop trigger update_trigger on priorities;
 drop trigger update_trigger on projects;
 drop trigger update_trigger on users;
-drop trigger update_trigger on project_users;
-drop trigger update_trigger on roles;
-drop trigger update_trigger on priorities;
+-- drop trigger update_trigger on project_users;
+-- drop trigger update_trigger on roles;
 
 drop routine if exists set_updated_at();
 

--- a/db/migrations/000002_add_update_trigger.up.sql
+++ b/db/migrations/000002_add_update_trigger.up.sql
@@ -12,6 +12,11 @@ CREATE TRIGGER update_trigger
 
 CREATE TRIGGER update_trigger
     AFTER UPDATE
+    ON priorities
+    FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+
+CREATE TRIGGER update_trigger
+    AFTER UPDATE
     ON projects
     FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
 
@@ -20,17 +25,13 @@ CREATE TRIGGER update_trigger
     ON users
     FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
 
-CREATE TRIGGER update_trigger
-    AFTER UPDATE
-    ON project_users
-    FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
-
-CREATE TRIGGER update_trigger
-    AFTER UPDATE
-    ON roles
-    FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
-
-CREATE TRIGGER update_trigger
-    AFTER UPDATE
-    ON priorities
-    FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+-- CREATE TRIGGER update_trigger
+--     AFTER UPDATE
+--     ON project_users
+--     FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+--
+-- CREATE TRIGGER update_trigger
+--     AFTER UPDATE
+--     ON roles
+--     FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+--

--- a/db/seeds/scenario.sql
+++ b/db/seeds/scenario.sql
@@ -1,18 +1,18 @@
--- user1がownerのプロジェクトにuser2が参加しtodoを共有する
-
 -- 初期値の設定
 INSERT INTO priorities ("name") VALUES ('high'), ('mid'), ('low');
-INSERT INTO roles ("role") VALUES ('editor'), ('admin');
 
--- user1, user2, user3を作成
-INSERT INTO users ("id", "auth0_id", "name", "email") VALUES ('1535c2ec-16e4-467d-8120-8ed642bbf7e7', 'auth0|01a11f28aacda01526480ddc','user1','user1@gmail.com');
-INSERT INTO users ("id", "auth0_id", "name", "email") VALUES ('2535c2ec-16e4-467d-8120-8ed642bbf7e7', 'auth0|02a11f28aacda01526480ddc','user2','user2@gmail.com');
-INSERT INTO users ("id", "auth0_id", "name", "email") VALUES ('3535c2ec-16e4-467d-8120-8ed642bbf7e7', 'google-oauth2|032852562224003772841','user3','user3@gmail.com');
+--  cli用のuser
+INSERT INTO users ("id", "auth0_id", "name", "email") VALUES ('1535c2ec-16e4-467d-8120-8ed642bbf7e7', 'iKbdoXOX3b6Bjg5BFnKKzUCgWzq3ic3w@clients','client','client@gmail.com');
+-- ブラウザ用のuser
+INSERT INTO users ("id", "auth0_id", "name", "email") VALUES ('2535c2ec-16e4-467d-8120-8ed642bbf7e7', 'google-oauth2|032852562224003772841','daisuke','daisukenoguemon@gmail.com');
 
--- user1がproject1を作成 = project1のオーナーがuser1
-INSERT INTO projects("id", "name", "invitation_token", "owner_id") VALUES ('d125b07b-9479-4adb-ab5d-1ac5cf8d27f8', 'project1', 'token', '1535c2ec-16e4-467d-8120-8ed642bbf7e7');
+-- cli用userがownerのproject
+INSERT INTO projects("id", "name", "owner_id") VALUES ('d125b07b-9479-4adb-ab5d-1ac5cf8d27f8', 'project1', '1535c2ec-16e4-467d-8120-8ed642bbf7e7');
+-- ブラウザuserがownerのプロジェクト
+INSERT INTO projects("id", "name", "owner_id") VALUES ('d225b07b-9479-4adb-ab5d-1ac5cf8d27f8', 'project2', '2535c2ec-16e4-467d-8120-8ed642bbf7e7');
 
 -- user1が未完了のhigh, mid, low 完了済みのhigh, mid, low 計6個todoを作成
+-- 現状memberは存在できない
 INSERT INTO todos ("id", "title", "description", "priority", "done", "project_id", "user_id") VALUES ('11f506ef-db2e-4cc1-a0e7-c7a068cd06bf', 'todo1', 'description1', 'high', false, 'd125b07b-9479-4adb-ab5d-1ac5cf8d27f8', '1535c2ec-16e4-467d-8120-8ed642bbf7e7');
 INSERT INTO todos ("id", "title", "description", "priority", "done", "project_id", "user_id") VALUES ('21f506ef-db2e-4cc1-a0e7-c7a068cd06bf', 'todo2', 'description2', 'mid', false, 'd125b07b-9479-4adb-ab5d-1ac5cf8d27f8', '1535c2ec-16e4-467d-8120-8ed642bbf7e7');
 INSERT INTO todos ("id", "title", "description", "priority", "done", "project_id", "user_id") VALUES ('31f506ef-db2e-4cc1-a0e7-c7a068cd06bf', 'todo3', 'description3', 'low', false, 'd125b07b-9479-4adb-ab5d-1ac5cf8d27f8', '1535c2ec-16e4-467d-8120-8ed642bbf7e7');
@@ -20,14 +20,3 @@ INSERT INTO todos ("id", "title", "description", "priority", "done", "project_id
 INSERT INTO todos ("id", "title", "description", "priority", "done", "project_id", "user_id") VALUES ('41f506ef-db2e-4cc1-a0e7-c7a068cd06bf', 'todo1', 'description1', 'high', true, 'd125b07b-9479-4adb-ab5d-1ac5cf8d27f8', '1535c2ec-16e4-467d-8120-8ed642bbf7e7');
 INSERT INTO todos ("id", "title", "description", "priority", "done", "project_id", "user_id") VALUES ('51f506ef-db2e-4cc1-a0e7-c7a068cd06bf', 'todo2', 'description2', 'mid', true, 'd125b07b-9479-4adb-ab5d-1ac5cf8d27f8', '1535c2ec-16e4-467d-8120-8ed642bbf7e7');
 INSERT INTO todos ("id", "title", "description", "priority", "done", "project_id", "user_id") VALUES ('61f506ef-db2e-4cc1-a0e7-c7a068cd06bf', 'todo3', 'description3', 'low', true, 'd125b07b-9479-4adb-ab5d-1ac5cf8d27f8', '1535c2ec-16e4-467d-8120-8ed642bbf7e7');
-
--- user2がメンバーとして加入
-INSERT INTO project_users ("id", "role", "project_id", "user_id") VALUES ('1509c316-343b-48f5-81d8-393032e4be0f', 'editor', 'd125b07b-9479-4adb-ab5d-1ac5cf8d27f8', '2535c2ec-16e4-467d-8120-8ed642bbf7e7');
-
--- 加入したuser2が未完了のhigh, mid, low 3つのタスクをもつ
--- id = 01b607ef-e183-42c7-8420-0540ce982024
--- project_id = d125b07b-9479-4adb-ab5d-1ac5cf8d27f8
--- user2のid = 2535c2ec-16e4-467d-8120-8ed642bbf7e7
-INSERT INTO todos ("id", "title", "description", "priority", "done", "project_id", "user_id") VALUES ('01b607ef-e183-42c7-8420-0540ce982024', 'todo1', 'description1', 'high', false, 'd125b07b-9479-4adb-ab5d-1ac5cf8d27f8', '2535c2ec-16e4-467d-8120-8ed642bbf7e7');
-INSERT INTO todos ("id", "title", "description", "priority", "done", "project_id", "user_id") VALUES ('02b607ef-e183-42c7-8420-0540ce982024', 'todo1', 'description1', 'mid', false, 'd125b07b-9479-4adb-ab5d-1ac5cf8d27f8', '2535c2ec-16e4-467d-8120-8ed642bbf7e7');
-INSERT INTO todos ("id", "title", "description", "priority", "done", "project_id", "user_id") VALUES ('03b607ef-e183-42c7-8420-0540ce982024', 'todo1', 'description1', 'low', false, 'd125b07b-9479-4adb-ab5d-1ac5cf8d27f8', '2535c2ec-16e4-467d-8120-8ed642bbf7e7');


### PR DESCRIPTION
# Jira
https://buysell-tech.atlassian.net/jira/software/projects/AC/boards/113?selectedIssue=AC-321

# 要件 
- DBの変更
- ERDの変更
- シナリオの変更

# やったこと
- 見積もりミスです！！！申し訳ないです！！！
- ERD
  - https://app.diagrams.net/#G13BaNKuxybE5U066W7M8DVOAn_6DuFdwi
  - project_usersテーブルの削除(projectに所属する機能の後回し)
  - project_usersテーブルに招待するための招待トークンカラム削除
- 変更をmigrationファイルに反映
  - わかりづらいのでinitそのものを書き直しています
- シナリオの変更
  - cli、ブラウザ用に一人づつユーザ作成
  - それぞれのユーザがオーナーのプロジェクトを作成

# 動作確認観点  
- [x] dbを作成し、シナリオが通ることを確認

# 意図
- 残り3稼働でバックエンドを終わらせたい為機能を限定
  - 拡張できる状態で、システムに表現する部分を削ぎ落とした 

具体的には、本来
- フロントで認証
- トークンからauth0id抜き出し
- ローカルDBでユーザ作成
- プロジェクト作成
- todo作成 or 招待でメンバーを増やす

想定でしたが、時間の都合上
- ローカルDBでユーザ作成
- プロジェクト作成
は一旦手作業で行い「事前に用意したProjectに、そのオーナーだけがtodoを作れる」アプリケーションとします

アプリケーションのゴール
- あらかじめ存在するプロジェクトに対して、そのオーナーが書き込み処理を行える事




